### PR TITLE
Set the preferred node version as default

### DIFF
--- a/nodejs/introduction.md
+++ b/nodejs/introduction.md
@@ -59,6 +59,8 @@ browser-sync start --server --directory --files "*"
 
     $ nvm use 4.3.2            # Use a specific version
 
+    # nvm alias default 20     # set the preferred version as default
+
 #### How to Install Multiple Versions of same package in NPM?
 
 ```sh


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an example command for setting a default Node.js version with nvm in the introduction guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->