### PR TITLE
Chrome: add keyboard shortcut to duplicate the current tab

### DIFF
--- a/Shortcuts/Keyboards/chrome.md
+++ b/Shortcuts/Keyboards/chrome.md
@@ -1,0 +1,16 @@
+## Keyboards Shortcuts for Chrome
+
+### Mixin
+
+#### Duplicate the current tab
+
+##### macos
+
+
+- <kbd>Cmd</kbd> + <kbd>L</kbd> - Takes the cursor to the address bar
+- <kbd>Opt</kbd> + <kbd>Enter</kbd> - Opens a new tab with this url
+
+##### windows
+
+- <kbd>Ctrl</kbd> + <kbd>L</kbd> - Takes the cursor to the address bar
+- <kbd>Alt</kbd> + <kbd>Enter</kbd> - Opens a new tab with this url


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Chrome keyboard shortcuts guide.
  * Includes a “Duplicate the current tab” mixin with platform-specific steps:
    - macOS: Cmd+L to focus address bar, then Option+Enter to open in a new tab.
    - Windows: Ctrl+L to focus address bar, then Alt+Enter to open in a new tab.
  * Improved readability with formatted keyboard key indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->